### PR TITLE
feat: upgrade renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,22 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>sparkfabrik/renovatebot-default-configuration"],
-  "customManagers": [
-    {
-      "customType": "regex",
-      "fileMatch": ["Makefile"],
-      "matchStrings": ["TERRAFORM_DOCS_VERSION \\?= (?<currentValue>.*?)\n"],
-      "depNameTemplate": "terraform_docs_makefile",
-      "versioningTemplate": "semver-coerced",
-      "datasourceTemplate": "custom.terraform_docs_makefile"
-    }
-  ],
-  "customDatasources": {
-    "terraform_docs_makefile": {
-      "defaultRegistryUrlTemplate": "https://quay.io/api/v1/repository/terraform-docs/terraform-docs/tag/",
-      "transformTemplates": [
-        "{ \"releases\": $map($.tags, function($v) { { \"version\": $v.name } }) }"
-      ]
-    }
-  }
+  "extends": [
+    "github>sparkfabrik/renovatebot-default-configuration",
+    "github>sparkfabrik/renovatebot-default-configuration//custom/terraform_docs"
+  ]
 }


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Simplified Renovate configuration by removing custom implementation for terraform-docs versioning
- Added terraform_docs extension from sparkfabrik's default configuration repository
- Improved maintainability by leveraging pre-existing configuration instead of custom regex and datasource definitions



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>renovate.json</strong><dd><code>Streamline Renovate configuration with terraform_docs extension</code></dd></summary>
<hr>

renovate.json

<li>Simplified configuration by removing custom managers and datasources<br> <li> Extended configuration to include terraform_docs from sparkfabrik's <br>default configuration<br>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/terraform-google-gcp-mysql-db-and-user-creation-helper/pull/12/files#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57">+4/-19</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information