### PR TITLE
fix: revoke cloudsqlsuperuser permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
-- Fix MySQL 8.0/8.4 provisioning failure caused by `Access Denied` (error 1045) on `REVOKE cloudsqlsuperuser`. The script now performs a `SHOW GRANTS` pre-check to verify whether the role is assigned before attempting the revoke, avoiding errors when the admin user lacks `ROLE_ADMIN` privileges.
+- Fix MySQL 8.0/8.4 provisioning failure caused by `Access Denied` (error 1045) on `SHOW GRANTS` and `REVOKE cloudsqlsuperuser`. On Cloud SQL MySQL 8.4, `activate_all_roles_on_login` is `OFF` and the admin's default role may not be initialized until after the first interactive login. The script now prepends `SET ROLE ALL;` to every MySQL statement to explicitly activate the `ROLE_ADMIN` privilege in each connection. Additionally, a `SHOW GRANTS` pre-check verifies whether the `cloudsqlsuperuser` role is assigned before attempting the revoke, and `SET DEFAULT ROLE NONE` is only executed when the role was actually revoked.
 
 ## [0.5.1] - 2025-11-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.5.2] - 2026-03-18
+
+[Compare with previous version](https://github.com/sparkfabrik/terraform-google-gcp-mysql-db-and-user-creation-helper/compare/0.5.1...0.5.2)
+
+### Fixed
+
+- Fix MySQL 8.0/8.4 provisioning failure caused by `Access Denied` (error 1045) on `REVOKE cloudsqlsuperuser`. The script now performs a `SHOW GRANTS` pre-check to verify whether the role is assigned before attempting the revoke, avoiding errors when the admin user lacks `ROLE_ADMIN` privileges.
+
 ## [0.5.1] - 2025-11-11
 
 [Compare with previous version](https://github.com/sparkfabrik/terraform-google-gcp-mysql-db-and-user-creation-helper/compare/0.5.0...0.5.1)

--- a/scripts/execute_sql.sh
+++ b/scripts/execute_sql.sh
@@ -49,10 +49,18 @@ if [ "$READY" -eq 0 ]; then
             SQL_COMMANDS="REVOKE ALL PRIVILEGES, GRANT OPTION FROM ${USER_IDENTIFIER}; GRANT ALL PRIVILEGES ON ${DATABASE_IDENTIFIER} TO ${USER_IDENTIFIER};"
             ;;
         MYSQL_8_0*|MYSQL_8_4*)
+            # On Cloud SQL MySQL 8.4, activate_all_roles_on_login is OFF and the
+            # admin's default role (cloudsqlsuperuser) may not be set until the
+            # admin has logged in interactively at least once. We prepend
+            # "SET ROLE ALL;" to every statement so that each independent
+            # mysql connection activates the full ROLE_ADMIN privileges needed
+            # for SHOW GRANTS and REVOKE operations on other users.
+            ROLE_PREFIX="SET ROLE ALL;"
+
             # Pre-check: verify whether the user has the cloudsqlsuperuser role
             # before attempting REVOKE, to avoid Access Denied (1045) errors when
             # the admin user lacks ROLE_ADMIN privileges.
-            if ! GRANTS_OUTPUT=$(mysql_exec --execute="SHOW GRANTS FOR ${USER_IDENTIFIER};" 2>&1); then
+            if ! GRANTS_OUTPUT=$(mysql_exec --execute="${ROLE_PREFIX} SHOW GRANTS FOR ${USER_IDENTIFIER};" 2>&1); then
                 log "ERROR: Failed to retrieve grants for ${USER_IDENTIFIER}."
                 log "${GRANTS_OUTPUT}" >&2
                 exit 1
@@ -62,7 +70,7 @@ if [ "$READY" -eq 0 ]; then
             if printf '%s' "${GRANTS_OUTPUT}" | grep -qi "GRANT 'cloudsqlsuperuser'"; then
                 HAS_SUPERUSER_ROLE=true
                 log "cloudsqlsuperuser role found for ${USER_IDENTIFIER}; revoking."
-                if ! REVOKE_OUTPUT=$(mysql_exec --execute="REVOKE cloudsqlsuperuser FROM ${USER_IDENTIFIER};" 2>&1); then
+                if ! REVOKE_OUTPUT=$(mysql_exec --execute="${ROLE_PREFIX} REVOKE cloudsqlsuperuser FROM ${USER_IDENTIFIER};" 2>&1); then
                     log "ERROR: Failed to revoke cloudsqlsuperuser role for ${USER_IDENTIFIER}."
                     log "${REVOKE_OUTPUT}" >&2
                     exit 1
@@ -73,9 +81,9 @@ if [ "$READY" -eq 0 ]; then
             fi
 
             if [ "${HAS_SUPERUSER_ROLE}" = true ]; then
-                SQL_COMMANDS="SET DEFAULT ROLE NONE TO ${USER_IDENTIFIER}; GRANT ALL PRIVILEGES ON ${DATABASE_IDENTIFIER} TO ${USER_IDENTIFIER};"
+                SQL_COMMANDS="${ROLE_PREFIX} SET DEFAULT ROLE NONE TO ${USER_IDENTIFIER}; GRANT ALL PRIVILEGES ON ${DATABASE_IDENTIFIER} TO ${USER_IDENTIFIER};"
             else
-                SQL_COMMANDS="GRANT ALL PRIVILEGES ON ${DATABASE_IDENTIFIER} TO ${USER_IDENTIFIER};"
+                SQL_COMMANDS="${ROLE_PREFIX} GRANT ALL PRIVILEGES ON ${DATABASE_IDENTIFIER} TO ${USER_IDENTIFIER};"
             fi
             ;;
         *)

--- a/scripts/execute_sql.sh
+++ b/scripts/execute_sql.sh
@@ -53,14 +53,18 @@ if [ "$READY" -eq 0 ]; then
             # before attempting REVOKE, to avoid Access Denied (1045) errors when
             # the admin user lacks ROLE_ADMIN privileges.
             if ! GRANTS_OUTPUT=$(mysql_exec --execute="SHOW GRANTS FOR ${USER_IDENTIFIER};" 2>&1); then
-                log "ERROR: Failed to retrieve grants for ${USER_IDENTIFIER}:\n${GRANTS_OUTPUT}" >&2
+                log "ERROR: Failed to retrieve grants for ${USER_IDENTIFIER}."
+                log "${GRANTS_OUTPUT}" >&2
                 exit 1
             fi
 
-            if printf '%s' "${GRANTS_OUTPUT}" | grep -qi "cloudsqlsuperuser"; then
+            HAS_SUPERUSER_ROLE=false
+            if printf '%s' "${GRANTS_OUTPUT}" | grep -qi "GRANT 'cloudsqlsuperuser'"; then
+                HAS_SUPERUSER_ROLE=true
                 log "cloudsqlsuperuser role found for ${USER_IDENTIFIER}; revoking."
                 if ! REVOKE_OUTPUT=$(mysql_exec --execute="REVOKE cloudsqlsuperuser FROM ${USER_IDENTIFIER};" 2>&1); then
-                    log "ERROR: Failed to revoke cloudsqlsuperuser role for ${USER_IDENTIFIER}:\n${REVOKE_OUTPUT}" >&2
+                    log "ERROR: Failed to revoke cloudsqlsuperuser role for ${USER_IDENTIFIER}."
+                    log "${REVOKE_OUTPUT}" >&2
                     exit 1
                 fi
                 log "Removed cloudsqlsuperuser role from ${USER_IDENTIFIER}."
@@ -68,7 +72,11 @@ if [ "$READY" -eq 0 ]; then
                 log "cloudsqlsuperuser role not found for ${USER_IDENTIFIER}; skipping REVOKE."
             fi
 
-            SQL_COMMANDS="SET DEFAULT ROLE NONE TO ${USER_IDENTIFIER}; GRANT ALL PRIVILEGES ON ${DATABASE_IDENTIFIER} TO ${USER_IDENTIFIER};"
+            if [ "${HAS_SUPERUSER_ROLE}" = true ]; then
+                SQL_COMMANDS="SET DEFAULT ROLE NONE TO ${USER_IDENTIFIER}; GRANT ALL PRIVILEGES ON ${DATABASE_IDENTIFIER} TO ${USER_IDENTIFIER};"
+            else
+                SQL_COMMANDS="GRANT ALL PRIVILEGES ON ${DATABASE_IDENTIFIER} TO ${USER_IDENTIFIER};"
+            fi
             ;;
         *)
             log "ERROR: Unsupported MySQL version ${MYSQL_VERSION}." >&2

--- a/scripts/execute_sql.sh
+++ b/scripts/execute_sql.sh
@@ -49,16 +49,25 @@ if [ "$READY" -eq 0 ]; then
             SQL_COMMANDS="REVOKE ALL PRIVILEGES, GRANT OPTION FROM ${USER_IDENTIFIER}; GRANT ALL PRIVILEGES ON ${DATABASE_IDENTIFIER} TO ${USER_IDENTIFIER};"
             ;;
         MYSQL_8_0*|MYSQL_8_4*)
-            if ! REVOKE_OUTPUT=$(mysql_exec --execute="REVOKE cloudsqlsuperuser FROM ${USER_IDENTIFIER};" 2>&1); then
-                if printf '%s' "${REVOKE_OUTPUT}" | grep -qi "Operation REVOKE ROLE failed"; then
-                    log "cloudsqlsuperuser role already absent for ${USER_IDENTIFIER}; continuing."
-                else
+            # Pre-check: verify whether the user has the cloudsqlsuperuser role
+            # before attempting REVOKE, to avoid Access Denied (1045) errors when
+            # the admin user lacks ROLE_ADMIN privileges.
+            if ! GRANTS_OUTPUT=$(mysql_exec --execute="SHOW GRANTS FOR ${USER_IDENTIFIER};" 2>&1); then
+                log "ERROR: Failed to retrieve grants for ${USER_IDENTIFIER}:\n${GRANTS_OUTPUT}" >&2
+                exit 1
+            fi
+
+            if printf '%s' "${GRANTS_OUTPUT}" | grep -qi "cloudsqlsuperuser"; then
+                log "cloudsqlsuperuser role found for ${USER_IDENTIFIER}; revoking."
+                if ! REVOKE_OUTPUT=$(mysql_exec --execute="REVOKE cloudsqlsuperuser FROM ${USER_IDENTIFIER};" 2>&1); then
                     log "ERROR: Failed to revoke cloudsqlsuperuser role for ${USER_IDENTIFIER}:\n${REVOKE_OUTPUT}" >&2
                     exit 1
                 fi
-            else
                 log "Removed cloudsqlsuperuser role from ${USER_IDENTIFIER}."
+            else
+                log "cloudsqlsuperuser role not found for ${USER_IDENTIFIER}; skipping REVOKE."
             fi
+
             SQL_COMMANDS="SET DEFAULT ROLE NONE TO ${USER_IDENTIFIER}; GRANT ALL PRIVILEGES ON ${DATABASE_IDENTIFIER} TO ${USER_IDENTIFIER};"
             ;;
         *)


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fix MySQL 8.0/8.4 `REVOKE cloudsqlsuperuser` causing `Access Denied` (1045) error

- Add `SHOW GRANTS` pre-check before attempting role revocation

- Skip revoke if role is absent, avoiding `ROLE_ADMIN` privilege requirement

- Update `CHANGELOG.md` with version `0.5.2` release notes


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["MySQL 8.0/8.4 provisioning"] -- "SHOW GRANTS FOR user" --> B["Check grants output"]
  B -- "cloudsqlsuperuser found" --> C["REVOKE cloudsqlsuperuser FROM user"]
  B -- "cloudsqlsuperuser not found" --> D["Skip REVOKE, log and continue"]
  C -- "success" --> E["Grant ALL PRIVILEGES on database"]
  C -- "failure" --> F["Log ERROR and exit 1"]
  D --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>execute_sql.sh</strong><dd><code>Add SHOW GRANTS pre-check before revoking cloudsqlsuperuser role</code></dd></summary>
<hr>

scripts/execute_sql.sh

<ul><li>Replace blind <code>REVOKE cloudsqlsuperuser</code> with a <code>SHOW GRANTS</code> pre-check to <br>detect role presence<br> <li> Only attempt revoke if <code>cloudsqlsuperuser</code> is found in grants output<br> <li> Log and skip revoke gracefully if role is absent, avoiding <code>Access </code><br><code>Denied</code> (1045) errors<br> <li> Exit with error if <code>SHOW GRANTS</code> itself fails</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/terraform-google-gcp-mysql-db-and-user-creation-helper/pull/25/files#diff-d836b1f5973561285ee5ffe6818ac0813d5595ecd7ef8e68a5c80ad8532499bc">+14/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document version 0.5.2 bug fix in changelog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Add new <code>0.5.2</code> release entry documenting the MySQL 8.0/8.4 provisioning <br>fix<br> <li> Describe the root cause and resolution of the <code>Access Denied</code> error on <br><code>REVOKE cloudsqlsuperuser</code></ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/terraform-google-gcp-mysql-db-and-user-creation-helper/pull/25/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

